### PR TITLE
fix readme json, add babel dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [standard-image]: https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square
 [standard-url]: http://npm.im/semistandard
 
-Tools to convert ArcGIS JSON geometries to GeoJSON geometries and vice-versa.
+Tools to convert ArcGIS JSON geometries to GeoJSON geometries and vice versa.
 
 ## Install
 
@@ -26,7 +26,7 @@ var arcgisToGeoJSON = require('arcgis-to-geojson').arcgisToGeoJSON;
 var geojsonToArcGIS = require('arcgis-to-geojson').geojsonToArcGIS;
 
 // parse ArcGIS JSON, convert it to GeoJSON
-var geojson = arcgisToGeoJSON.parse({
+var geojson = arcgisToGeoJSON({
     "x":-122.6764,
     "y":45.5165,
     "spatialReference": {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [standard-image]: https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square
 [standard-url]: http://npm.im/semistandard
 
-Tools to convert ArcGIS JSON geometries to GeoJSON geometries and vica-versa.
+Tools to convert ArcGIS JSON geometries to GeoJSON geometries and vice-versa.
 
 ## Install
 
@@ -25,23 +25,23 @@ npm install arcgis-to-geojson
 var arcgisToGeoJSON = require('arcgis-to-geojson').arcgisToGeoJSON;
 var geojsonToArcGIS = require('arcgis-to-geojson').geojsonToArcGIS;
 
-// parse ArcGIS JSON, convert it to a Terraformer.Primitive (GeoJSON)
+// parse ArcGIS JSON, convert it to GeoJSON
 var geojson = arcgisToGeoJSON.parse({
-    x:"-122.6764",
-    y:"45.5165",
-    spatialReference: {
-      wkid: 4326
+    "x":-122.6764,
+    "y":45.5165,
+    "spatialReference": {
+      "wkid": 4326
     }
   });
 
-// take a Terraformer.Primitive or GeoJSON and convert it back to ArcGIS JSON
+// take GeoJSON and convert it to ArcGIS JSON
 var arcgis = geojsonToArcGIS({
   "type": "Point",
   "coordinates": [45.5165, -122.6764]
 });
 ```
 
-This module is distributed as a [UMD]() module and can also be used in AMD based systems or as a global under the `ArcgisToGeojsonUtils` namespace.
+This package is distributed as a [UMD]() module and can also be used in AMD based systems or as a global under the `ArcgisToGeojsonUtils` namespace.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# arcgis-to-geojson
+# arcgis-to-geojson-utils
 
 [![npm][npm-image]][npm-url]
 [![travis][travis-image]][travis-url]
 [![standard][standard-image]][standard-url]
 
-[npm-image]: https://img.shields.io/npm/v/arcgis-to-geojson.svg?style=flat-square
-[npm-url]: https://www.npmjs.com/package/arcgis-to-geojson
-[travis-image]: https://img.shields.io/travis/patrickarlt/arcgis-to-geojson.svg?style=flat-square
-[travis-url]: https://travis-ci.org/patrickarlt/arcgis-to-geojson
+[npm-image]: https://img.shields.io/npm/v/arcgis-to-geojson-utils.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/arcgis-to-geojson-utils
+[travis-image]: https://img.shields.io/travis/Esri/arcgis-to-geojson.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-to-geojson
 [standard-image]: https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square
 [standard-url]: http://npm.im/semistandard
 
@@ -16,14 +16,14 @@ Tools to convert ArcGIS JSON geometries to GeoJSON geometries and vice versa.
 ## Install
 
 ```
-npm install arcgis-to-geojson
+npm install arcgis-to-geojson-utils
 ```
 
 ## Usage
 
 ```js
-var arcgisToGeoJSON = require('arcgis-to-geojson').arcgisToGeoJSON;
-var geojsonToArcGIS = require('arcgis-to-geojson').geojsonToArcGIS;
+var arcgisToGeoJSON = require('arcgis-to-geojson-utils').arcgisToGeoJSON;
+var geojsonToArcGIS = require('arcgis-to-geojson-utils').geojsonToArcGIS;
 
 // parse ArcGIS JSON, convert it to GeoJSON
 var geojson = arcgisToGeoJSON({

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
+    "babel-preset-es2015": "^6.1.18",
+    "babelify": "^7.2.0",
+    "browserify": "^12.0.1",
     "faucet": "0.0.1",
     "gh-release": "^2.0.2",
     "rollup": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "scripts": {
     "lint": "semistandard | snazzy",
-    "test:node": "babel-node test/index.js | faucet",
-    "test:browser": "browserify test/index.js -t [ babelify --loose ] --debug | tape-run | faucet",
+    "test:node": "babel-node test/index.js [ babelify --presets es2015 ] | faucet",
+    "test:browser": "browserify test/index.js -t [ babelify --presets es2015 ] --debug | tape-run | faucet",
     "test": "npm run lint && npm run test:node && npm run test:browser",
     "release": "./release.sh",
     "bundle": "rollup index.js -m dist/arcgis-to-geojson.js.map -f umd -o dist/arcgis-to-geojson.js -n ArcgisToGeojsonUtils",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/esri/arcgis-to-geojson/issues"
   },
   "devDependencies": {
+    "babel-cli": "^6.3.17",
     "faucet": "0.0.1",
     "gh-release": "^2.0.2",
     "rollup": "^0.21.0",


### PR DESCRIPTION
fixed ArcGIS json syntax in readme (since the [WKT parser](http://terraformer.io/wkt-parser/) isn't included in this module).

tests are failing for me locally, even after trying to clean up the `devDependencies`

```
/Users/john6251/github/arcgis-to-geojson/test/index.js:1
(function (exports, require, module, __filename, __dirname) { import test from 'tape';
                                                              ^^^^^^

SyntaxError: Unexpected reserved word
...
not ok 1 no plan found
not ok 2 no assertions found
⨯ fail  2
```

looks like travis is blowing up on [leaflet-virtual-grid](https://travis-ci.org/patrickarlt/leaflet-virtual-grid) with more or less the same error, but locally i can get _those_ tests to pass.
