### PR TITLE
add check for empty geometry object to catch situations when input was invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,6 +280,7 @@ export function arcgisToGeoJSON (arcgis, idAttribute) {
     }
   }
 
+  // if no valid geometry was encountered
   if (JSON.stringify(geojson.geometry) === JSON.stringify({})) {
     geojson.geometry = null;
   }

--- a/index.js
+++ b/index.js
@@ -280,6 +280,10 @@ export function arcgisToGeoJSON (arcgis, idAttribute) {
     }
   }
 
+  if (JSON.stringify(geojson.geometry) === JSON.stringify({})) {
+    geojson.geometry = null;
+  }
+
   return geojson;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -721,6 +721,25 @@ test('should parse an ArcGIS Null Island in a GeoJSON Point', function (t) {
   t.deepEqual(output.coordinates, [0, 0]);
 });
 
+test('should not pass along geometry when nothing valid is encountered in input', function (t) {
+  t.plan(2);
+
+  var input = {
+    'geometry': {
+      'x': 'NaN',
+      'y': 'NaN'
+    },
+    'attributes': {
+      'foo': 'bar'
+    }
+  };
+
+  var output = arcgisToGeoJSON(input);
+
+  t.deepEqual(output.properties.foo, 'bar');
+  t.deepEqual(output.geometry, null);
+});
+
 test('should parse an ArcGIS Polyline in a GeoJSON LineString', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
resolves #8

currently `terraformer-arcgis-parser` throws an [error](https://github.com/Esri/Terraformer/blob/master/terraformer.js#L97) when encountering an unexpected geometry and this module passes along an empty `{}`.

i don't mind just throwing an error here too, but it seems better to pass along a `null` geometry when we fail to parse the input than it does to blow up entirely.

i'm happy to rethink/refactor if anyone else disagrees.
