### PR TITLE
Remove es6 feature to allow minification

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,4 +346,4 @@ export function geojsonToArcGIS (geojson, idAttribute) {
   return result;
 }
 
-export default { arcgisToGeoJSON, geojsonToArcGIS };
+export default { arcgisToGeoJSON: arcgisToGeoJSON, geojsonToArcGIS: geojsonToArcGIS };


### PR DESCRIPTION
On attempting to use this package in a React app created with [Create React App](https://github.com/facebookincubator/create-react-app), the use of es6 shorthand object properties in dist/index.js causes Uglify.js to fail. See https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify.
