### PR TITLE
convert ArcGIS features array to GeoJSON FeatureCollection

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,14 @@ function getId (attributes, idAttribute) {
 export function arcgisToGeoJSON (arcgis, idAttribute) {
   var geojson = {};
 
+  if (arcgis.features) {
+    geojson.type = 'FeatureCollection';
+    geojson.features = [];
+    for (var i = 0; i < arcgis.features.length; i++) {
+      geojson.features.push(arcgisToGeoJSON(arcgis.features[i]));
+    }
+  }
+
   if (typeof arcgis.x === 'number' && typeof arcgis.y === 'number') {
     geojson.type = 'Point';
     geojson.coordinates = [arcgis.x, arcgis.y];

--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ export function arcgisToGeoJSON (arcgis, idAttribute) {
     geojson.type = 'FeatureCollection';
     geojson.features = [];
     for (var i = 0; i < arcgis.features.length; i++) {
-      geojson.features.push(arcgisToGeoJSON(arcgis.features[i]));
+      geojson.features.push(arcgisToGeoJSON(arcgis.features[i], idAttribute));
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1212,6 +1212,106 @@ test('should parse an ArcGIS Feature into a GeoJSON Feature', function (t) {
   t.equal(output.geometry.type, 'Polygon');
 });
 
+test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON FeatureCollection', function (t) {
+  t.plan(1);
+
+  var input = {
+    'displayFieldName': 'prop0',
+    'fieldAliases': {'prop0': 'prop0'},
+    'geometryType': 'esriGeometryPolygon',
+    'fields': [
+      {
+        'name': 'prop0',
+        'type': 'esriFieldTypeString',
+        'alias': 'prop0',
+        'length': 20
+      }
+    ],
+    'spatialReference': { 'wkid': 4326 },
+    'features': [
+      {
+        'geometry': {
+          'x': 102,
+          'y': 0.5
+        },
+        'attributes': {
+          'prop0': 'value0'
+        }
+      }, {
+        'geometry': {
+          'paths': [
+            [[102, 0],
+              [103, 1],
+              [104, 0],
+              [105, 1]]
+          ]
+        },
+        'attributes': {
+          'prop0': 'value0'
+        }
+      }, {
+        'geometry': {
+          'rings': [
+            [ [100, 0],
+              [100, 1],
+              [101, 1],
+              [101, 0],
+              [100, 0] ]
+          ]
+        },
+        'attributes': {
+          'prop0': 'value0'
+        }
+      }
+    ]
+  };
+
+  var output = arcgisToGeoJSON(input);
+
+  t.deepEqual(output, {
+    'type': 'FeatureCollection',
+    'features': [{
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [102.0, 0.5]
+      },
+      'properties': {
+        'prop0': 'value0'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'LineString',
+        'coordinates': [
+          [102.0, 0.0],
+          [103.0, 1.0],
+          [104.0, 0.0],
+          [105.0, 1.0]
+        ]
+      },
+      'properties': {
+        'prop0': 'value0'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [ [100.0, 0.0],
+            [101.0, 0.0],
+            [101.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 0.0] ]
+        ]
+      },
+      'properties': {
+        'prop0': 'value0'
+      }
+    }]
+  });
+});
+
 test('should parse an ArcGIS Feature w/ OBJECTID into a GeoJSON Feature', function (t) {
   t.plan(1);
 

--- a/test/index.js
+++ b/test/index.js
@@ -1225,6 +1225,16 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
         'type': 'esriFieldTypeString',
         'alias': 'prop0',
         'length': 20
+      },
+      {
+        'name': 'OBJECTID',
+        'type': 'esriFieldTypeOID',
+        'alias': 'OBJECTID'
+      },
+      {
+        'name': 'FID',
+        'type': 'esriFieldTypeDouble',
+        'alias': 'FID'
       }
     ],
     'spatialReference': { 'wkid': 4326 },
@@ -1235,7 +1245,9 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
           'y': 0.5
         },
         'attributes': {
-          'prop0': 'value0'
+          'prop0': 'value0',
+          'OBJECTID': 0,
+          'FID': 0
         }
       }, {
         'geometry': {
@@ -1247,7 +1259,9 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
           ]
         },
         'attributes': {
-          'prop0': 'value0'
+          'prop0': null,
+          'OBJECTID': null,
+          'FID': 1
         }
       }, {
         'geometry': {
@@ -1260,13 +1274,15 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
           ]
         },
         'attributes': {
-          'prop0': 'value0'
+          'prop0': null,
+          'OBJECTID': 2,
+          'FID': 30.25
         }
       }
     ]
   };
 
-  var output = arcgisToGeoJSON(input);
+  var output = arcgisToGeoJSON(input, 'prop0');
 
   t.deepEqual(output, {
     'type': 'FeatureCollection',
@@ -1277,8 +1293,11 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
         'coordinates': [102.0, 0.5]
       },
       'properties': {
-        'prop0': 'value0'
-      }
+        'prop0': 'value0',
+        'OBJECTID': 0,
+        'FID': 0
+      },
+      'id': 'value0'
     }, {
       'type': 'Feature',
       'geometry': {
@@ -1291,8 +1310,11 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
         ]
       },
       'properties': {
-        'prop0': 'value0'
-      }
+        'prop0': null,
+        'OBJECTID': null,
+        'FID': 1
+      },
+      'id': 1
     }, {
       'type': 'Feature',
       'geometry': {
@@ -1306,8 +1328,11 @@ test('should convert ArcGIS JSON with an array of ArcGIS Features into a GeoJSON
         ]
       },
       'properties': {
-        'prop0': 'value0'
-      }
+        'prop0': null,
+        'OBJECTID': 2,
+        'FID': 30.25
+      },
+      'id': 2
     }]
   });
 });


### PR DESCRIPTION
In the same way that `geojsonToArcGIS()` converts a `FeatureCollection` to a `features` array, the corresponding inverse behaviour should be true for `arcgisToGeoJSON()`