### PR TITLE
Parse of ArcGIS extents into GeoJSON polygons

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,22 @@ export function arcgisToGeoJSON (arcgis, idAttribute) {
     geojson = convertRingsToGeoJSON(arcgis.rings.slice(0));
   }
 
+  if (
+    typeof arcgis.xmin === 'number' &&
+    typeof arcgis.ymin === 'number' &&
+    typeof arcgis.xmax === 'number' &&
+    typeof arcgis.ymax === 'number'
+  ) {
+    geojson.type = 'Polygon';
+    geojson.coordinates = [[
+      [arcgis.xmax, arcgis.ymax],
+      [arcgis.xmin, arcgis.ymax],
+      [arcgis.xmin, arcgis.ymin],
+      [arcgis.xmax, arcgis.ymin],
+      [arcgis.xmax, arcgis.ymax]
+    ]];
+  }
+
   if (arcgis.geometry || arcgis.attributes) {
     geojson.type = 'Feature';
     geojson.geometry = (arcgis.geometry) ? arcgisToGeoJSON(arcgis.geometry) : null;

--- a/test/index.js
+++ b/test/index.js
@@ -1616,3 +1616,22 @@ test('should not modify the original ArcGIS Geometry', function (t) {
 
   t.equal(original, JSON.stringify(input));
 });
+
+test('should parse an ArcGIS Extent into a Terraformer GeoJSON Polygon', function (t) {
+  t.plan(2);
+
+  var input = {
+    'xmax': -35.5078125,
+    'ymax': 41.244772343082076,
+    'xmin': -13.7109375,
+    'ymin': 54.36775852406841,
+    'spatialReference': {
+      'wkid': 4326
+    }
+  };
+
+  var output = arcgisToGeoJSON(input);
+
+  t.deepEqual(output.coordinates, [[[-35.5078125, 41.244772343082076], [-13.7109375, 41.244772343082076], [-13.7109375, 54.36775852406841], [-35.5078125, 54.36775852406841], [-35.5078125, 41.244772343082076]]]);
+  t.equal(output.type, 'Polygon');
+});


### PR DESCRIPTION
This PR adds the ability to parse ArcGIS extents into GeoJSON polygons

Ported from Esri/terraformer-arcgis-parser#53